### PR TITLE
Added integration tests, fixed creating empty IFEO when only Affinity is present, fixed issue with getting empty configurations.

### DIFF
--- a/src/Cpu_affinity.sln
+++ b/src/Cpu_affinity.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PPM.Unsafe", "PPM.Unsafe\PP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PPM.Application.Tests", "PPM.Application.Tests\PPM.Application.Tests.csproj", "{F522FFDA-B24C-46BE-8DE3-8EA38355BA0A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PPM.Application.IntegrationTests", "PPM.Application.IntegrationTests\PPM.Application.IntegrationTests.csproj", "{A3A8DC94-FFA2-4B6E-9AA0-FF5FDB5EE9BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -52,6 +54,10 @@ Global
 		{F522FFDA-B24C-46BE-8DE3-8EA38355BA0A}.Debug|x64.Build.0 = Debug|x64
 		{F522FFDA-B24C-46BE-8DE3-8EA38355BA0A}.Release|x64.ActiveCfg = Release|x64
 		{F522FFDA-B24C-46BE-8DE3-8EA38355BA0A}.Release|x64.Build.0 = Release|x64
+		{A3A8DC94-FFA2-4B6E-9AA0-FF5FDB5EE9BA}.Debug|x64.ActiveCfg = Debug|x64
+		{A3A8DC94-FFA2-4B6E-9AA0-FF5FDB5EE9BA}.Debug|x64.Build.0 = Debug|x64
+		{A3A8DC94-FFA2-4B6E-9AA0-FF5FDB5EE9BA}.Release|x64.ActiveCfg = Release|x64
+		{A3A8DC94-FFA2-4B6E-9AA0-FF5FDB5EE9BA}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/PPM.Application.IntegrationTests/Model/CRUD/ProcessConfigurationRepositoryTests.cs
+++ b/src/PPM.Application.IntegrationTests/Model/CRUD/ProcessConfigurationRepositoryTests.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using Affinity_manager.Model;
+using Affinity_manager.Model.CRUD;
+using Microsoft.Win32;
+using NUnit.Framework;
+
+namespace PPM.Application.IntegrationTests.Model.CRUD
+{
+    [TestFixture]
+    public class ProcessConfigurationRepositoryTests
+    {
+        private const string IfeoRegistryKeyPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options";
+        private const string AppOptionsRegistryKeyPath = @"SOFTWARE\Processes Priority Manager";
+        private const string PerfOptionsSubKey = "PerfOptions";
+
+        private string _ifeoRegistryBackupPath;
+        private string? _appRegistryBackupPath;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            using (Registry.LocalMachine.OpenSubKey(IfeoRegistryKeyPath, true)) { };
+            _ifeoRegistryBackupPath = Path.Combine(Path.GetTempPath(), "backupIfeo.hiv");
+            RegistryTestsHelpers.BackupRegistryKey(IfeoRegistryKeyPath, _ifeoRegistryBackupPath);
+            if (Registry.LocalMachine.OpenSubKey(AppOptionsRegistryKeyPath, false) != null)
+            {
+                _appRegistryBackupPath = Path.Combine(Path.GetTempPath(), "backupApp.hiv");
+                RegistryTestsHelpers.BackupRegistryKey(AppOptionsRegistryKeyPath, _appRegistryBackupPath);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            RegistryTestsHelpers.RestoreRegistryKey(IfeoRegistryKeyPath, _ifeoRegistryBackupPath);
+            File.Delete(_ifeoRegistryBackupPath);
+            if (_appRegistryBackupPath != null)
+            {
+                RegistryTestsHelpers.RestoreRegistryKey(AppOptionsRegistryKeyPath, _appRegistryBackupPath);
+                File.Delete(_appRegistryBackupPath);
+            }
+            else
+            {
+                Registry.LocalMachine.DeleteSubKeyTree(AppOptionsRegistryKeyPath, false);
+            }
+        }
+
+        [Test]
+        public void CleanWithoutServiceRestart_ThenAllRelatedItemsFromRegistryAreRemoved()
+        {
+            ProcessConfiguration configuration = new(TestContext.CurrentContext.Random.GetString())
+            {
+                IoPriority = IoPriority.High
+            };
+
+            ProcessConfiguration configuration1 = new(TestContext.CurrentContext.Random.GetString())
+            {
+                CpuPriority = CpuPriorityClass.High,
+                CpuAffinityMask = 1234
+            };
+
+            ProcessConfiguration configuration2 = new(TestContext.CurrentContext.Random.GetString())
+            {
+                CpuAffinityMask = 1U
+            };
+
+            ProcessConfigurationsRepository repository = new();
+            repository.Save([configuration, configuration1, configuration2]);
+
+            repository.CleanWithoutServiceRestart();
+
+            Assert.That(repository.Get(), Is.Empty);
+        }
+    }
+}

--- a/src/PPM.Application.IntegrationTests/Model/CRUD/ProcessConfigurationsRegistryManagerTests.cs
+++ b/src/PPM.Application.IntegrationTests/Model/CRUD/ProcessConfigurationsRegistryManagerTests.cs
@@ -1,0 +1,335 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Affinity_manager.Model;
+using Affinity_manager.Model.CRUD;
+using Microsoft.Win32;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace PPM.Application.IntegrationTests.Model.CRUD
+{
+    [TestFixture]
+    internal class ProcessConfigurationsRegistryManagerTests
+    {
+        private const string IfeoRegistryKeyPath = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options";
+        private const string AppOptionsRegistryKeyPath = @"SOFTWARE\Processes Priority Manager";
+        private const string PerfOptionsSubKey = "PerfOptions";
+        private const string CpuPriorityClassValueName = "CpuPriorityClass";
+        private const string IoPriorityValueName = "IoPriority";
+        private string _ifeoRegistryBackupPath;
+        private string? _appRegistryBackupPath;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            using (Registry.LocalMachine.OpenSubKey(IfeoRegistryKeyPath, true)) { };
+            _ifeoRegistryBackupPath = Path.Combine(Path.GetTempPath(), "backupIfeo.hiv");
+            BackupRegistryKey(IfeoRegistryKeyPath, _ifeoRegistryBackupPath);
+            if (Registry.LocalMachine.OpenSubKey(AppOptionsRegistryKeyPath, false) != null)
+            {
+                _appRegistryBackupPath = Path.Combine(Path.GetTempPath(), "backupApp.hiv");
+                BackupRegistryKey(AppOptionsRegistryKeyPath, _appRegistryBackupPath);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            RestoreRegistryKey(IfeoRegistryKeyPath, _ifeoRegistryBackupPath);
+            File.Delete(_ifeoRegistryBackupPath);
+            if (_appRegistryBackupPath != null)
+            {
+                RestoreRegistryKey(AppOptionsRegistryKeyPath, _appRegistryBackupPath);
+                File.Delete(_appRegistryBackupPath);
+            }
+            else
+            {
+                Registry.LocalMachine.DeleteSubKeyTree(AppOptionsRegistryKeyPath, false);
+            }
+        }
+
+        [Test]
+        public void LoadFromRegistry_ReturnsPerformanceOptionsFromIFEO()
+        {
+            // Arrange
+            ProcessConfigurationsRegistryManager manager = new();
+            string imageName = TestContext.CurrentContext.Test.Name;
+            string testKeyPath = Path.Combine(IfeoRegistryKeyPath, imageName);
+            string testPerfOptionsPath = Path.Combine(testKeyPath, PerfOptionsSubKey);
+
+            using (RegistryKey testKey = Registry.LocalMachine.CreateSubKey(testKeyPath))
+            {
+                using RegistryKey perfOptionsKey = testKey.CreateSubKey(PerfOptionsSubKey);
+                perfOptionsKey.SetValue(CpuPriorityClassValueName, (int)CpuPriorityClass.High, RegistryValueKind.DWord);
+                perfOptionsKey.SetValue(IoPriorityValueName, (int)IoPriority.Critical, RegistryValueKind.DWord);
+            }
+
+            try
+            {
+                List<ProcessConfiguration> configurations = manager.LoadFromRegistry();
+                AssertProcessConfigurationPerformance(imageName, configurations, (CpuPriorityClass.High, IoPriority.Critical));
+            }
+            finally
+            {
+                Registry.LocalMachine.DeleteSubKeyTree(testKeyPath);
+            }
+        }
+
+        [Test]
+        public void LoadFromRegistry_ReturnsWhenCpuPriorityHasWrongType()
+        {
+            // Arrange
+            ProcessConfigurationsRegistryManager manager = new();
+            string imageName = TestContext.CurrentContext.Test.Name;
+            string testKeyPath = Path.Combine(IfeoRegistryKeyPath, imageName);
+            string testPerfOptionsPath = Path.Combine(testKeyPath, PerfOptionsSubKey);
+
+            using (RegistryKey testKey = Registry.LocalMachine.CreateSubKey(testKeyPath))
+            {
+                using RegistryKey perfOptionsKey = testKey.CreateSubKey(PerfOptionsSubKey);
+                perfOptionsKey.SetValue(CpuPriorityClassValueName, "InvalidType", RegistryValueKind.String);
+                perfOptionsKey.SetValue(IoPriorityValueName, (int)IoPriority.Critical, RegistryValueKind.DWord);
+            }
+
+            try
+            {
+                List<ProcessConfiguration> configurations = manager.LoadFromRegistry();
+                AssertProcessConfigurationPerformance(imageName, configurations, (CpuPriorityClass.Normal, IoPriority.Critical));
+            }
+            finally
+            {
+                Registry.LocalMachine.DeleteSubKeyTree(testKeyPath);
+            }
+        }
+
+        [Test]
+        public void LoadFromRegistry_ReturnsWhenIoPriorityHasWrongType()
+        {
+            // Arrange
+            ProcessConfigurationsRegistryManager manager = new();
+            string imageName = TestContext.CurrentContext.Test.Name;
+            string testKeyPath = Path.Combine(IfeoRegistryKeyPath, imageName);
+            string testPerfOptionsPath = Path.Combine(testKeyPath, PerfOptionsSubKey);
+
+            using (RegistryKey testKey = Registry.LocalMachine.CreateSubKey(testKeyPath))
+            {
+                using RegistryKey perfOptionsKey = testKey.CreateSubKey(PerfOptionsSubKey);
+                perfOptionsKey.SetValue(CpuPriorityClassValueName, (int)CpuPriorityClass.Low, RegistryValueKind.DWord);
+                perfOptionsKey.SetValue(IoPriorityValueName, "1", RegistryValueKind.String);
+            }
+
+
+            try
+            {
+                List<ProcessConfiguration> configurations = manager.LoadFromRegistry();
+                AssertProcessConfigurationPerformance(imageName, configurations, (CpuPriorityClass.Low, IoPriority.Normal));
+            }
+            finally
+            {
+                Registry.LocalMachine.DeleteSubKeyTree(testKeyPath);
+            }
+        }
+
+        [Test]
+        public void LoadFromRegistry_ReturnsFromBothLocations()
+        {
+            // Arrange
+            ProcessConfigurationsRegistryManager manager = new();
+            string imageName = TestContext.CurrentContext.Test.Name;
+            string imageOptionsTestKeyPath = Path.Combine(ImageOptionsFiller.ImageOptionsRegistryPath, imageName);
+            string ifeoTestKeyPath = Path.Combine(IfeoRegistryKeyPath, imageName);
+
+            using (RegistryKey testKey = Registry.LocalMachine.CreateSubKey(imageOptionsTestKeyPath))
+            {
+                testKey.SetValue(ImageOptionsFiller.AffinityValueName, 123L, RegistryValueKind.QWord);
+            }
+
+            using (RegistryKey testKey = Registry.LocalMachine.CreateSubKey(ifeoTestKeyPath))
+            {
+                using RegistryKey perfOptionsKey = testKey.CreateSubKey(PerfOptionsSubKey);
+                perfOptionsKey.SetValue(CpuPriorityClassValueName, (int)CpuPriorityClass.Low, RegistryValueKind.DWord);
+                perfOptionsKey.SetValue(IoPriorityValueName, (int)IoPriority.VeryLow, RegistryValueKind.DWord);
+            }
+
+            try
+            {
+                // Act
+                List<ProcessConfiguration> configurations = manager.LoadFromRegistry();
+
+                // Assert
+                ProcessConfiguration? config = configurations.SingleOrDefault(c => c.Name == imageName);
+                Assert.That(config, Is.Not.Null);
+                Assert.That(config.CpuAffinityMask, Is.EqualTo(123U));
+                Assert.That(config.CpuPriority, Is.EqualTo(CpuPriorityClass.Low));
+                Assert.That(config.IoPriority, Is.EqualTo(IoPriority.VeryLow));
+            }
+            finally
+            {
+                // Cleanup
+                Registry.LocalMachine.DeleteSubKeyTree(imageOptionsTestKeyPath);
+                Registry.LocalMachine.DeleteSubKeyTree(ifeoTestKeyPath);
+            }
+        }
+
+        [Test]
+        public void SaveToRegistry_SavesPerformanceOptionsToIFEO()
+        {
+            // Arrange
+            ProcessConfigurationsRegistryManager manager = new();
+            string imageName = TestContext.CurrentContext.Test.Name;
+            string testKeyPath = Path.Combine(IfeoRegistryKeyPath, imageName);
+            ProcessConfiguration config = new(imageName)
+            {
+                CpuPriority = CpuPriorityClass.AboveNormal,
+                IoPriority = IoPriority.High
+            };
+
+            try
+            {
+                // Act
+                manager.SaveToRegistry([config]);
+
+                // Assert
+                using (RegistryKey? testKey = Registry.LocalMachine.OpenSubKey(testKeyPath))
+                {
+                    Assert.That(testKey, Is.Not.Null);
+                    using RegistryKey? perfOptionsKey = testKey.OpenSubKey(PerfOptionsSubKey);
+                    Assert.That(perfOptionsKey, Is.Not.Null);
+                    Assert.That(perfOptionsKey.GetValue(CpuPriorityClassValueName), Is.EqualTo((int)CpuPriorityClass.AboveNormal));
+                    Assert.That(perfOptionsKey.GetValue(IoPriorityValueName), Is.EqualTo((int)IoPriority.High));
+                }
+
+                // Now lets try to reset and save it again
+                config.Reset();
+                config.CpuAffinityMask = 123U; // With this it should still remove IFEO options
+                manager.SaveToRegistry([config]);
+
+                using (RegistryKey? testKey = Registry.LocalMachine.OpenSubKey(testKeyPath))
+                {
+                    Assert.That(testKey, Is.Null);
+                }
+            }
+            finally
+            {
+                // Cleanup
+                Registry.LocalMachine.DeleteSubKeyTree(testKeyPath, false);
+            }
+        }
+
+        [Test]
+        public void SaveToRegistry_RemovesEmptySubKeysInIFEO()
+        {
+            // Arrange
+            ProcessConfigurationsRegistryManager manager = new();
+            string imageName = TestContext.CurrentContext.Test.Name;
+            string testKeyPath = Path.Combine(IfeoRegistryKeyPath, imageName);
+            ProcessConfiguration config = new(imageName);
+            config.CpuAffinityMask = 123U; // This should not create any IFEO options
+
+            // Act
+            manager.SaveToRegistry(new List<ProcessConfiguration> { config });
+
+            // Assert
+            using (RegistryKey? testKey = Registry.LocalMachine.OpenSubKey(testKeyPath))
+            {
+                Assert.That(testKey, Is.Null);
+            }
+        }
+
+        [Test]
+        public void SaveToRegistry_SavesAffinityToImageOptions()
+        {
+            // Arrange
+            ProcessConfigurationsRegistryManager manager = new();
+            string imageName = TestContext.CurrentContext.Test.Name;
+            string testKeyPath = Path.Combine(ImageOptionsFiller.ImageOptionsRegistryPath, imageName);
+            ProcessConfiguration config = new(imageName)
+            {
+                CpuAffinityMask = 123U
+            };
+
+            try
+            {
+                // Act
+                manager.SaveToRegistry(new List<ProcessConfiguration> { config });
+
+                // Assert
+                using (RegistryKey? testKey = Registry.LocalMachine.OpenSubKey(testKeyPath))
+                {
+                    Assert.That(testKey, Is.Not.Null);
+                    Assert.That(testKey.GetValue(ImageOptionsFiller.AffinityValueName), Is.EqualTo((long)config.CpuAffinityMask));
+                }
+
+                // Now lets try to reset and save it again
+                config.Reset();
+                manager.SaveToRegistry(new List<ProcessConfiguration> { config });
+
+                using (RegistryKey? testKey = Registry.LocalMachine.OpenSubKey(testKeyPath))
+                {
+                    Assert.That(testKey, Is.Null);
+                }
+            }
+            finally
+            {
+                // Cleanup
+                Registry.LocalMachine.DeleteSubKeyTree(testKeyPath, false);
+            }
+        }
+
+        private static void AssertProcessConfigurationPerformance(string imageName, List<ProcessConfiguration> configurations, (CpuPriorityClass, IoPriority) expectedValues)
+        {
+            Assert.That(configurations, Is.Not.Null);
+            Assert.That(configurations, Is.Not.Empty);
+            ProcessConfiguration? testConfig = configurations.FirstOrDefault(c => c.Name == imageName);
+            Assert.That(testConfig, Is.Not.Null);
+            Assert.That(testConfig.CpuPriority, Is.EqualTo(expectedValues.Item1));
+            Assert.That(testConfig.IoPriority, Is.EqualTo(expectedValues.Item2));
+        }
+
+        private static void BackupRegistryKey(string keyPath, string backupFilePath)
+        {
+            System.Diagnostics.Process process = new()
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "reg.exe",
+                    Arguments = $"save \"HKLM\\{keyPath}\" \"{backupFilePath}\" /y",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                Assert.Fail($"Backup creation failed with {process.ExitCode}. Note that these test must run with admin rights.");
+            }
+        }
+
+        private static void RestoreRegistryKey(string keyPath, string backupFilePath)
+        {
+            if (File.Exists(backupFilePath))
+            {
+                System.Diagnostics.Process process = new()
+                {
+                    StartInfo = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "reg.exe",
+                        Arguments = $"restore \"HKLM\\{keyPath}\" \"{backupFilePath}\"",
+                        RedirectStandardOutput = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+                process.Start();
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    ClassicAssert.Fail($"Backup restoration failed with {process.ExitCode}. Note that these test must run with admin rights.");
+                }
+            }
+        }
+    }
+}

--- a/src/PPM.Application.IntegrationTests/Model/CRUD/RegistryTestsHelpers.cs
+++ b/src/PPM.Application.IntegrationTests/Model/CRUD/RegistryTestsHelpers.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace PPM.Application.IntegrationTests.Model.CRUD
+{
+    internal static class RegistryTestsHelpers
+    {
+        public static void BackupRegistryKey(string keyPath, string backupFilePath)
+        {
+            System.Diagnostics.Process process = new()
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "reg.exe",
+                    Arguments = $"save \"HKLM\\{keyPath}\" \"{backupFilePath}\" /y",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                Assert.Fail($"Backup creation failed with {process.ExitCode}. Note that these test must run with admin rights.");
+            }
+        }
+
+        public static void RestoreRegistryKey(string keyPath, string backupFilePath)
+        {
+            if (File.Exists(backupFilePath))
+            {
+                System.Diagnostics.Process process = new()
+                {
+                    StartInfo = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "reg.exe",
+                        Arguments = $"restore \"HKLM\\{keyPath}\" \"{backupFilePath}\"",
+                        RedirectStandardOutput = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+                process.Start();
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    ClassicAssert.Fail($"Backup restoration failed with {process.ExitCode}. Note that these test must run with admin rights.");
+                }
+            }
+        }
+    }
+}

--- a/src/PPM.Application.IntegrationTests/PPM.Application.IntegrationTests.csproj
+++ b/src/PPM.Application.IntegrationTests/PPM.Application.IntegrationTests.csproj
@@ -1,0 +1,60 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup Label="Globals">
+	  <WebView2EnableCsWinRTProjection>False</WebView2EnableCsWinRTProjection>
+	</PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<RootNamespace>PPM.Application.IntegrationTests</RootNamespace>
+		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<UseWinUI>true</UseWinUI>
+		<IsTestProject>true</IsTestProject>
+		<EnableMsixTooling>true</EnableMsixTooling>
+		<IsPackable>false</IsPackable>
+		<Platforms>x64</Platforms>
+		<SelfContained>true</SelfContained>
+		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+	  <Compile Remove="bin\**" />
+	  <Compile Remove="TestResults\**" />
+	  <EmbeddedResource Remove="bin\**" />
+	  <EmbeddedResource Remove="TestResults\**" />
+	  <None Remove="bin\**" />
+	  <None Remove="TestResults\**" />
+	  <Page Remove="bin\**" />
+	  <Page Remove="TestResults\**" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FakeItEasy" Version="8.3.0" />
+		<PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+		<PackageReference Include="NUnit" Version="4.3.2" />
+		<PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\PPM.Application\PPM.Application.csproj" />
+	</ItemGroup>
+	<PropertyGroup>
+		<BaseOutputPath>..\bin\</BaseOutputPath>
+	</PropertyGroup>
+	<ItemGroup>
+	  <PRIResource Remove="bin\**" />
+	</ItemGroup>
+	<ItemGroup>
+	  <PRIResource Remove="TestResults\**" />
+	</ItemGroup>
+</Project>

--- a/src/PPM.Application.Tests/ViewModels/MainPageViewModelTests.cs
+++ b/src/PPM.Application.Tests/ViewModels/MainPageViewModelTests.cs
@@ -84,7 +84,7 @@ namespace PPM.Application.Tests.ViewModels
             await _viewModel.SaveChangesAsync();
 
             // Assert
-            A.CallTo(() => _repository.SaveAsync(A<IEnumerable<ProcessConfiguration>>.That.IsSameSequenceAs(new[] { processConfiguration }), A<Func<Task>>.That.IsNotNull())).MustHaveHappened()
+            A.CallTo(() => _repository.SaveAndRestartServiceAsync(A<IEnumerable<ProcessConfiguration>>.That.IsSameSequenceAs(new[] { processConfiguration }), A<Func<Task>>.That.IsNotNull())).MustHaveHappened()
                 .Then(A.CallTo(() => _repository.Get()).MustHaveHappened());
             monitor.Should().RaisePropertyChangeFor((viewModel) => viewModel.ProcessesConfigurations);
             monitor.Should().RaisePropertyChangeFor((viewModel) => viewModel.SaveCancelAvailable);
@@ -120,7 +120,7 @@ namespace PPM.Application.Tests.ViewModels
             await _viewModel.SaveChangesAsync();
 
             // Assert
-            A.CallTo(() => _repository.SaveAsync(A<IEnumerable<ProcessConfiguration>>.Ignored, A<Func<Task>>.Ignored)).MustHaveHappened()
+            A.CallTo(() => _repository.SaveAndRestartServiceAsync(A<IEnumerable<ProcessConfiguration>>.Ignored, A<Func<Task>>.Ignored)).MustHaveHappened()
                 .Then(A.CallTo(() => _repository.Get()).MustHaveHappened());
             monitor.Should().RaisePropertyChangeFor((viewModel) => viewModel.ProcessesConfigurations);
             monitor.Should().RaisePropertyChangeFor((viewModel) => viewModel.SaveCancelAvailable);
@@ -149,13 +149,13 @@ namespace PPM.Application.Tests.ViewModels
         public void SaveChangesAsync_ShouldShowMessage_WhenServiceNotInstalledExceptionIsThrown()
         {
             // Arrange
-            A.CallTo(() => _repository.SaveAsync(A<IEnumerable<ProcessConfiguration>>.Ignored, A<Func<Task>>.Ignored))
+            A.CallTo(() => _repository.SaveAndRestartServiceAsync(A<IEnumerable<ProcessConfiguration>>.Ignored, A<Func<Task>>.Ignored))
                 .Throws(new ServiceNotInstalledException("Name"));
             using FluentAssertions.Events.IMonitor<MainPageViewModel> monitor = _viewModel.Monitor();
 
             // Act & Assert
             Assert.DoesNotThrowAsync(() => _viewModel.SaveChangesAsync());
-            A.CallTo(() => _repository.SaveAsync(A<IEnumerable<ProcessConfiguration>>.Ignored, A<Func<Task>>.Ignored)).MustHaveHappened();
+            A.CallTo(() => _repository.SaveAndRestartServiceAsync(A<IEnumerable<ProcessConfiguration>>.Ignored, A<Func<Task>>.Ignored)).MustHaveHappened();
 
             monitor.Should().Raise(nameof(_viewModel.ShowMessage)).WithArgs<string>((message) => message.Contains("Service"));
         }

--- a/src/PPM.Application/App.xaml.cs
+++ b/src/PPM.Application/App.xaml.cs
@@ -44,7 +44,7 @@ namespace Affinity_manager
             if (Environment.GetCommandLineArgs().Contains("--clear"))
             {
                 ProcessConfigurationsRepository cleaner = new();
-                cleaner.Clean();
+                cleaner.CleanWithoutServiceRestart();
                 Environment.Exit(0);
             }
 

--- a/src/PPM.Application/Model/CRUD/IProcessConfigurationsRepository.cs
+++ b/src/PPM.Application/Model/CRUD/IProcessConfigurationsRepository.cs
@@ -7,6 +7,6 @@ namespace Affinity_manager.Model.CRUD
     public interface IProcessConfigurationsRepository
     {
         List<ProcessConfiguration> Get();
-        Task SaveAsync(IEnumerable<ProcessConfiguration> items, Func<Task>? readyToGetCallback = null);
+        Task SaveAndRestartServiceAsync(IEnumerable<ProcessConfiguration> items, Func<Task>? readyToGetCallback = null);
     }
 }

--- a/src/PPM.Application/Model/CRUD/ProcessConfigurationsRegistryManager.cs
+++ b/src/PPM.Application/Model/CRUD/ProcessConfigurationsRegistryManager.cs
@@ -62,7 +62,7 @@ namespace Affinity_manager.Model.CRUD
                 RegistryKey? subKey = ifeoSubKey.OpenSubKey(item.Name, true);
                 if (subKey == null)
                 {
-                    if (item.IsEmpty)
+                    if (IfeoOptionsAreEmpty(item))
                     {
                         continue;
                     }
@@ -74,7 +74,7 @@ namespace Affinity_manager.Model.CRUD
                 {
                     FillSubKey(item, subKey);
 
-                    if (item.IsEmpty && subKey.ValueCount == 0 && subKey.SubKeyCount == 0)
+                    if (IfeoOptionsAreEmpty(item) && subKey.ValueCount == 0 && subKey.SubKeyCount == 0)
                     {
                         subKey.DeleteSubKey(string.Empty);
                     }
@@ -136,6 +136,11 @@ namespace Affinity_manager.Model.CRUD
             }
 
             return defaultValue;
+        }
+
+        private static bool IfeoOptionsAreEmpty(ProcessConfiguration config)
+        {
+            return config.CpuPriority == ProcessConfiguration.CpuPriorityDefaultValue && config.IoPriority == ProcessConfiguration.IoPriorityDefaultValue;
         }
     }
 }

--- a/src/PPM.Application/Model/CRUD/ProcessConfigurationsRegistryManager.cs
+++ b/src/PPM.Application/Model/CRUD/ProcessConfigurationsRegistryManager.cs
@@ -34,8 +34,15 @@ namespace Affinity_manager.Model.CRUD
                     object? cpuPriorityClass = perfOptions.GetValue(CpuPriorityClassName);
                     object? ioPriority = perfOptions.GetValue(IoPriorityName);
 
-                    processAffinity.CpuPriority = GetEnumValue(cpuPriorityClass, CpuPriorityClass.Normal);
-                    processAffinity.IoPriority = GetEnumValue(ioPriority, IoPriority.Normal);
+                    bool read = false;
+
+                    processAffinity.CpuPriority = GetEnumValue(cpuPriorityClass, CpuPriorityClass.Normal, ref read);
+                    processAffinity.IoPriority = GetEnumValue(ioPriority, IoPriority.Normal, ref read);
+
+                    if (!read)
+                    {
+                        continue;
+                    }
 
                     imageOptionsFiller.ReadAffinityFromRegistry(processAffinity);
 
@@ -127,11 +134,12 @@ namespace Affinity_manager.Model.CRUD
             }
         }
 
-        private static T GetEnumValue<T>(object? value, T defaultValue)
+        private static T GetEnumValue<T>(object? value, T defaultValue, ref bool read)
             where T : struct, Enum
         {
             if (value is int enumValueInt && Enum.IsDefined(typeof(T), (uint)enumValueInt))
             {
+                read = true;
                 return (T)Enum.ToObject(typeof(T), (uint)enumValueInt);
             }
 

--- a/src/PPM.Application/Model/CRUD/ProcessConfigurationsRepository.cs
+++ b/src/PPM.Application/Model/CRUD/ProcessConfigurationsRepository.cs
@@ -18,11 +18,10 @@ namespace Affinity_manager.Model.CRUD
 
         public void Save(IEnumerable<ProcessConfiguration> items)
         {
-            _processAffinitiesManager.SaveToRegistry(items);
-            RestartService();
+            Save(items, false);
         }
 
-        public async Task SaveAsync(IEnumerable<ProcessConfiguration> items, Func<Task>? readyToGetCallback = null)
+        public async Task SaveAndRestartServiceAsync(IEnumerable<ProcessConfiguration> items, Func<Task>? readyToGetCallback = null)
         {
             await Task.Run(() => _processAffinitiesManager.SaveToRegistry(items));
 
@@ -36,7 +35,7 @@ namespace Affinity_manager.Model.CRUD
             }
         }
 
-        public void Clean()
+        public void CleanWithoutServiceRestart()
         {
             List<ProcessConfiguration> processAffinities = Get();
             foreach (ProcessConfiguration processAffinity in processAffinities)
@@ -44,7 +43,16 @@ namespace Affinity_manager.Model.CRUD
                 processAffinity.Reset();
             }
 
-            Save(processAffinities);
+            Save(processAffinities, false);
+        }
+
+        private void Save(IEnumerable<ProcessConfiguration> items, bool restartService)
+        {
+            _processAffinitiesManager.SaveToRegistry(items);
+            if (restartService)
+            {
+                RestartService();
+            }
         }
 
         private void RestartService()

--- a/src/PPM.Application/ViewModels/IMainPageViewModel.cs
+++ b/src/PPM.Application/ViewModels/IMainPageViewModel.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Threading.Tasks;
 using Affinity_manager.Model;
 using Affinity_manager.ViewWrappers;
 using CommunityToolkit.Mvvm.Input;

--- a/src/PPM.Application/ViewModels/MainPageViewModel.cs
+++ b/src/PPM.Application/ViewModels/MainPageViewModel.cs
@@ -80,7 +80,7 @@ namespace Affinity_manager.ViewModels
             try
             {
 
-                await Repository.SaveAsync(ProcessesConfigurations.Where(item => item.IsDirty).Select(
+                await Repository.SaveAndRestartServiceAsync(ProcessesConfigurations.Where(item => item.IsDirty).Select(
                     item => item.ProcessConfiguration),
                     () =>
                     {

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -10,3 +10,4 @@ using System.Runtime.CompilerServices;
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]
 
 [assembly: InternalsVisibleTo("PPM.Application.Tests")]
+[assembly: InternalsVisibleTo("PPM.Application.IntegrationTests")]


### PR DESCRIPTION
#### PR Classification
New feature and code refactor to enhance integration testing and repository operations.

#### PR Summary
Introduced integration tests and refactored repository methods to improve functionality and testing.
- Added `PPM.Application.IntegrationTests` project with integration tests in `ProcessConfigurationRepositoryTests.cs` and `ProcessConfigurationsRegistryManagerTests.cs`.
- Introduced `RegistryTestsHelpers` for registry backup and restore in integration tests.
- Renamed `SaveAsync` to `SaveAndRestartServiceAsync` in `IProcessConfigurationsRepository` and updated related calls in `MainPageViewModelTests.cs`.
- Updated `ProcessConfigurationsRegistryManager.cs` with a new method `IfeoOptionsAreEmpty` and modified `GetEnumValue` to use a `ref` parameter.
- Refactored `ProcessConfigurationsRepository.cs` to include a private `Save` method with optional service restart.
