### PR TITLE
Added feature: applying to the running processes

### DIFF
--- a/src/PPM.Application.IntegrationTests/Model/ProcessConfigurationApplierTests.cs
+++ b/src/PPM.Application.IntegrationTests/Model/ProcessConfigurationApplierTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Affinity_manager.Model;
+using NUnit.Framework;
+using PPM.Unsafe;
+
+namespace PPM.Application.IntegrationTests.Model
+{
+    [TestFixture]
+    public class ProcessConfigurationApplierTests
+    {
+        private Process? _testAppProcess;
+
+        [SetUp]
+        public void Setup()
+        {
+            Process.GetProcessesByName("PPM.TestApp").ToList().ForEach(p => p.Kill());
+
+            _testAppProcess = Process.Start(new ProcessStartInfo { FileName = "PPM.TestApp.exe", UseShellExecute = true });
+            _testAppProcess!.ProcessorAffinity = 1;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testAppProcess?.Kill();
+            _testAppProcess?.Dispose();
+        }
+
+        [Test]
+        public void ApplyIfPresent_AppliesConfigurationOnOneProcess()
+        {
+            ProcessConfiguration configuration = new("PPM.TestApp.exe")
+            {
+                CpuPriority = CpuPriorityClass.Low,
+                CpuAffinityMask = 0xFul << 63 | 2,
+                IoPriority = IoPriority.Low,
+                MemoryPriority = PagePriority.Medium
+            };
+
+            ProcessConfigurationApplier applier = new();
+            applier.ApplyIfPresent((byte)Environment.ProcessorCount, configuration);
+
+            using Process? process = Process.GetProcessesByName("PPM.TestApp").FirstOrDefault();
+            Assert.That(process, Is.Not.Null);
+
+            Assert.That(process.PriorityClass, Is.EqualTo(ProcessPriorityClass.Idle));
+            Assert.That(process.ProcessorAffinity, Is.EqualTo((IntPtr)2));
+            Assert.That(process.GetIoPriority(), Is.EqualTo(IoPriorityHint.Low));
+            Assert.That(process.GetMemoryPriority(), Is.EqualTo(PagePriorityInformation.Medium));
+        }
+    }
+}

--- a/src/PPM.Application.IntegrationTests/PPM.Application.IntegrationTests.csproj
+++ b/src/PPM.Application.IntegrationTests/PPM.Application.IntegrationTests.csproj
@@ -47,6 +47,7 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\PPM.Application\PPM.Application.csproj" />
+	  <ProjectReference Include="..\PPM.TestApp\PPM.TestApp.csproj" />
 	</ItemGroup>
 	<PropertyGroup>
 		<BaseOutputPath>..\bin\</BaseOutputPath>

--- a/src/PPM.Application.Tests/ViewWrappers/ProcessConfigurationViewEqualityComparerTests.cs
+++ b/src/PPM.Application.Tests/ViewWrappers/ProcessConfigurationViewEqualityComparerTests.cs
@@ -1,24 +1,27 @@
 using Affinity_manager.Model;
 using Affinity_manager.ViewWrappers;
+using FakeItEasy;
 using NUnit.Framework;
 
 namespace PPM.Application.Tests.ViewWrappers
 {
     [TestFixture]
-    public class ProcessConfigurationEqualityComparerTests
+    public class ProcessConfigurationViewEqualityComparerTests
     {
         private ProcessConfigurationViewEqualityComparer _comparer;
+        private IProcessConfigurationApplier _configurationApplier;
 
         [SetUp]
         public void SetUp()
         {
             _comparer = new ProcessConfigurationViewEqualityComparer();
+            _configurationApplier = A.Fake<IProcessConfigurationApplier>();
         }
 
         [Test]
         public void Equals_SameReference_ReturnsTrue()
         {
-            ProcessConfigurationView configView = new(new ProcessConfiguration("Test"), new OptionsProvider());
+            ProcessConfigurationView configView = new(new ProcessConfiguration("Test"), new OptionsProvider(), _configurationApplier);
             Assert.That(_comparer.Equals(configView, configView));
         }
 
@@ -31,7 +34,7 @@ namespace PPM.Application.Tests.ViewWrappers
         [Test]
         public void Equals_OneNull_ReturnsFalse()
         {
-            ProcessConfigurationView configView = new(new ProcessConfiguration("Test"), new OptionsProvider());
+            ProcessConfigurationView configView = new(new ProcessConfiguration("Test"), new OptionsProvider(), _configurationApplier);
             Assert.That(_comparer.Equals(configView, null), Is.False);
             Assert.That(_comparer.Equals(null, configView), Is.False);
         }
@@ -39,32 +42,32 @@ namespace PPM.Application.Tests.ViewWrappers
         [Test]
         public void Equals_DifferentNames_ReturnsFalse()
         {
-            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test1"), new OptionsProvider());
-            ProcessConfigurationView configView2 = new(new ProcessConfiguration("Test2"), new OptionsProvider());
+            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test1"), new OptionsProvider(), _configurationApplier);
+            ProcessConfigurationView configView2 = new(new ProcessConfiguration("Test2"), new OptionsProvider(), _configurationApplier);
             Assert.That(_comparer.Equals(configView1, configView2), Is.False);
         }
 
         [Test]
         public void Equals_SameNamesDifferentCase_ReturnsTrue()
         {
-            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test"), new OptionsProvider());
-            ProcessConfigurationView configView2 = new(new ProcessConfiguration("test"), new OptionsProvider());
+            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test"), new OptionsProvider(), _configurationApplier);
+            ProcessConfigurationView configView2 = new(new ProcessConfiguration("test"), new OptionsProvider(), _configurationApplier);
             Assert.That(_comparer.Equals(configView1, configView2));
         }
 
         [Test]
         public void GetHashCode_SameNameDifferentCase_ReturnsSameHashCode()
         {
-            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test"), new OptionsProvider());
-            ProcessConfigurationView configView2 = new(new ProcessConfiguration("test"), new OptionsProvider());
+            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test"), new OptionsProvider(), _configurationApplier);
+            ProcessConfigurationView configView2 = new(new ProcessConfiguration("test"), new OptionsProvider(), _configurationApplier);
             Assert.That(_comparer.GetHashCode(configView2), Is.EqualTo(_comparer.GetHashCode(configView1)));
         }
 
         [Test]
         public void GetHashCode_DifferentNames_ReturnsDifferentHashCodes()
         {
-            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test1"), new OptionsProvider());
-            ProcessConfigurationView configView2 = new(new ProcessConfiguration("Test2"), new OptionsProvider());
+            ProcessConfigurationView configView1 = new(new ProcessConfiguration("Test1"), new OptionsProvider(), _configurationApplier);
+            ProcessConfigurationView configView2 = new(new ProcessConfiguration("Test2"), new OptionsProvider(), _configurationApplier);
             Assert.That(_comparer.GetHashCode(configView2), Is.Not.EqualTo(_comparer.GetHashCode(configView1)));
         }
     }

--- a/src/PPM.Application.Tests/ViewWrappers/ProcessConfigurationViewFactoryTests.cs
+++ b/src/PPM.Application.Tests/ViewWrappers/ProcessConfigurationViewFactoryTests.cs
@@ -12,6 +12,7 @@ namespace PPM.Application.Tests.ViewWrappers
     {
         private IOptionsProvider _optionsProvider;
         private IEqualityComparer<ProcessConfigurationView> _comparer;
+        private IProcessConfigurationApplier _configurationApplier;
         private ProcessConfigurationViewFactory _factory;
 
         [SetUp]
@@ -19,7 +20,8 @@ namespace PPM.Application.Tests.ViewWrappers
         {
             _optionsProvider = A.Fake<IOptionsProvider>();
             _comparer = A.Fake<IEqualityComparer<ProcessConfigurationView>>();
-            _factory = new ProcessConfigurationViewFactory(_optionsProvider, _comparer);
+            _configurationApplier = A.Fake<IProcessConfigurationApplier>();
+            _factory = new ProcessConfigurationViewFactory(_optionsProvider, _comparer, _configurationApplier);
         }
 
         [Test]
@@ -36,6 +38,7 @@ namespace PPM.Application.Tests.ViewWrappers
             Assert.That(result, Is.InstanceOf<ProcessConfigurationView>());
             Assert.That(result.ProcessConfiguration, Is.SameAs(configuration));
             Assert.That(result.OptionsProvider, Is.SameAs(_optionsProvider));
+            Assert.That(result.ConfigurationApplier, Is.SameAs(_configurationApplier));
         }
 
         [Test]

--- a/src/PPM.Application/Model/CRUD/ProcessConfigurationsRepository.cs
+++ b/src/PPM.Application/Model/CRUD/ProcessConfigurationsRepository.cs
@@ -26,6 +26,11 @@ namespace Affinity_manager.Model.CRUD
         public async Task SaveAndRestartServiceAsync(IEnumerable<ProcessConfiguration> items, Func<Task>? readyToGetCallback = null)
         {
             ProcessConfiguration[] itemsArray = items.ToArray();
+            if (itemsArray.Length == 0)
+            {
+                return;
+            }
+
             ThrowIfHaveInvalidNonEmptyItems(itemsArray);
 
             await Task.Run(() => _processAffinitiesManager.SaveToRegistry(items));

--- a/src/PPM.Application/Model/DataGathering/ProcessesMonitor.cs
+++ b/src/PPM.Application/Model/DataGathering/ProcessesMonitor.cs
@@ -72,7 +72,7 @@ namespace Affinity_manager.Model.DataGathering
                 }
                 catch (Win32Exception)
                 {
-                    // System process or exited process, just skip it.
+                    // System process just skip it.
                     _processesToIgnore[process.ProcessName] = 0;
                 }
                 catch (InvalidOperationException)

--- a/src/PPM.Application/Model/IProcessConfigurationApplier.cs
+++ b/src/PPM.Application/Model/IProcessConfigurationApplier.cs
@@ -1,0 +1,7 @@
+namespace Affinity_manager.Model
+{
+    public interface IProcessConfigurationApplier
+    {
+        bool ApplyIfPresent(byte processorCount, ProcessConfiguration configuration);
+    }
+}

--- a/src/PPM.Application/Model/ProcessConfigurationApplier.cs
+++ b/src/PPM.Application/Model/ProcessConfigurationApplier.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using PPM.Unsafe;
+
+namespace Affinity_manager.Model
+{
+    public class ProcessConfigurationApplier : IProcessConfigurationApplier
+    {
+        public bool ApplyIfPresent(byte processorCount, ProcessConfiguration configuration)
+        {
+            bool applied = false;
+            nint processorMask = CalculateProcessorMask(processorCount);
+            foreach (Process process in Process.GetProcessesByName(Path.GetFileNameWithoutExtension(configuration.Name)))
+            {
+                try
+                {
+                    UpdateProcess(process, configuration, processorMask);
+                    applied = true;
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process was already terminated, ignore.
+                }
+            }
+            return applied;
+        }
+
+        private static void UpdateProcess(Process process, ProcessConfiguration configuration, nint processorMask)
+        {
+            process.PriorityClass = Map(configuration.CpuPriority);
+            if (processorMask > 0)
+            {
+                unchecked
+                {
+                    process.ProcessorAffinity = ((nint)configuration.CpuAffinityMask) & processorMask;
+                }
+            }
+
+            process.SetIoPriority((IoPriorityHint)configuration.IoPriority);
+            process.SetMemoryPriority((PagePriorityInformation)configuration.MemoryPriority);
+        }
+
+        private static nint CalculateProcessorMask(byte processorCount)
+        {
+            return processorCount == 0 ? 0 : (1 << processorCount) - 1;
+        }
+
+        private static ProcessPriorityClass Map(CpuPriorityClass value)
+        {
+            return value switch
+            {
+                CpuPriorityClass.Low => ProcessPriorityClass.Idle,
+                CpuPriorityClass.BelowNormal => ProcessPriorityClass.BelowNormal,
+                CpuPriorityClass.Normal => ProcessPriorityClass.Normal,
+                CpuPriorityClass.AboveNormal => ProcessPriorityClass.AboveNormal,
+                CpuPriorityClass.High => ProcessPriorityClass.High,
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+            };
+        }
+    }
+}

--- a/src/PPM.Application/MultilingualResources/PPM.Application.uk-UA.xlf
+++ b/src/PPM.Application/MultilingualResources/PPM.Application.uk-UA.xlf
@@ -30,10 +30,6 @@
           <source>IO and Memory Priority</source>
           <target state="final">Пріоритет Вх/Вих та ОЗП</target>
         </trans-unit>
-        <trans-unit id="ApplyButton.Content" translate="yes" xml:space="preserve">
-          <source>Apply</source>
-          <target state="final">Застосувати</target>
-        </trans-unit>
         <trans-unit id="CancelButton.Content" translate="yes" xml:space="preserve">
           <source>Cancel</source>
           <target state="final">Відмінити</target>
@@ -79,6 +75,34 @@
         <trans-unit id="ResetButton.Content" translate="yes" xml:space="preserve">
           <source>Default</source>
           <target state="final">За замовчуванням</target>
+        </trans-unit>
+        <trans-unit id="SaveButton.Content" translate="yes" xml:space="preserve">
+          <source>Save</source>
+          <target state="final">Зберегти</target>
+        </trans-unit>
+        <trans-unit id="ApplyOnRunningCheckBox.Content" translate="yes" xml:space="preserve">
+          <source>Also apply on running processes</source>
+          <target state="final">Також застосувати до запущених процесів</target>
+        </trans-unit>
+        <trans-unit id="ApplyOnRunningCheckBox.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Instruct PPM to search for running processes and apply selected options during the save operation.</source>
+          <target state="final">Вказати PPM, що під час зберігання треба знайти та застосувати налаштування до запущений процесів.</target>
+        </trans-unit>
+        <trans-unit id="SaveButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Saves the changes. Configuration will be applied next time when the new instance of the process will start.</source>
+          <target state="final">Зберігає зміни. Налаштування будуть застосовані до процесів, які будуть запущені у майбутньому.</target>
+        </trans-unit>
+        <trans-unit id="ApplyOnRunningButton.Content" translate="yes" xml:space="preserve">
+          <source>Apply on running processes</source>
+          <target state="final">Застосувати до запущений процесів</target>
+        </trans-unit>
+        <trans-unit id="ApplyOnRunningButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Finds related running processes and applies the configuration on them.</source>
+          <target state="final">Знайти запущені процеси та застосувати ці налаштування до них.</target>
+        </trans-unit>
+        <trans-unit id="ResetButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Resets the configuration to the default state.</source>
+          <target state="final">Скидує до налаштувань за замовчуванням.</target>
         </trans-unit>
       </group>
     </body>
@@ -191,7 +215,7 @@
         </trans-unit>
         <trans-unit id="ProcessorConfigurationModifiedToolTipEnd" translate="yes" xml:space="preserve">
           <source>Click Apply to save the changes.</source>
-          <target state="translated">Натисніть "Застосувати", щоб зберегти зміни.</target>
+          <target state="final">Натисніть "Застосувати", щоб зберегти зміни.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/PPM.Application/PPM.Application.csproj
+++ b/src/PPM.Application/PPM.Application.csproj
@@ -70,6 +70,7 @@
     </PackageReference>
     <PackageReference Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.1" />
+    <PackageReference Include="Vanara.PInvoke.NtDll" Version="4.0.4" />
     <PackageReference Include="Vanara.PInvoke.User32" Version="4.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PPM.Application/PPM.Application.csproj
+++ b/src/PPM.Application/PPM.Application.csproj
@@ -70,8 +70,6 @@
     </PackageReference>
     <PackageReference Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.1" />
-    <PackageReference Include="Vanara.PInvoke.NtDll" Version="4.0.4" />
-    <PackageReference Include="Vanara.PInvoke.User32" Version="4.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/PPM.Application/Pages/MainPage.xaml
+++ b/src/PPM.Application/Pages/MainPage.xaml
@@ -25,6 +25,7 @@
                     <Style TargetType="TextBox" BasedOn="{StaticResource AutoSuggestBoxTextBoxStyle}">
                         <Setter Property="IsSpellCheckEnabled" Value="False"/>
                         <Setter Property="MaxLength" Value="100"/>
+                        <Setter Property="AccessKey" Value="A"/>
                     </Style>
                 </AutoSuggestBox.TextBoxStyle>
                 <AutoSuggestBox.ItemTemplate>
@@ -109,11 +110,12 @@
                                                   x:Uid="MemoryPriorityCombobox"/>
                                     </userControls:ControlWithHeader>
                                 </StackPanel>
-                                <StackPanel Grid.Row="1" Orientation="Horizontal" FlowDirection="RightToLeft"
-                                            Spacing="8" Padding="8"
-                                            Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}">
-                                    <Button x:Uid="ResetButton" Command="{x:Bind ResetCommand}" MinWidth="100"></Button>    
-                                </StackPanel>
+                                <Border Grid.Row="1" Padding="8" Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}">
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" >
+                                        <Button x:Uid="ApplyOnRunningButton" Command="{x:Bind ApplyCommand}" MinWidth="100">Apply</Button>
+                                        <Button x:Uid="ResetButton" Command="{x:Bind ResetCommand}" MinWidth="100"></Button>
+                                    </StackPanel>
+                                </Border>
                             </Grid>
                         </Expander.Content>
                     </Expander>
@@ -134,15 +136,16 @@
                 </TransitionCollection>
             </ListView.ItemContainerTransitions>
         </ListView>
-        <StackPanel Orientation="Horizontal" FlowDirection="RightToLeft"
-                    Grid.Column="0" Grid.Row="3" 
-                    Spacing="8"
-                    Padding="16,16" Background="{ThemeResource LayerOnMicaBaseAltFillColorSecondaryBrush}">
-            <Button x:Uid="CancelButton" IsEnabled="{x:Bind ViewModel.SaveCancelAvailable, Mode=OneWay}" Command="{x:Bind ViewModel.ReloadCommand}"
-                    Width="100" AccessKey="C"  TabIndex="1"/>
-            <Button x:Uid="ApplyButton" x:Name="saveButton" IsEnabled="{x:Bind ViewModel.SaveCancelAvailable, Mode=OneWay}" Style="{ThemeResource AccentButtonStyle}" Command="{x:Bind ViewModel.SaveChangesCommand}"
-                    Width="100" Content="Apply" AccessKey="A" TabIndex="0"/>
-        </StackPanel>
+
+        <Border Background="{ThemeResource LayerOnMicaBaseAltFillColorSecondaryBrush}" Padding="16,16" Grid.Column="0" Grid.Row="3">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <CheckBox x:Uid="ApplyOnRunningCheckBox" IsChecked="{x:Bind ViewModel.ApplyOnRunningProcesses, Mode=TwoWay}" AccessKey="R"/>
+                <Button x:Uid="SaveButton" x:Name="saveButton" IsEnabled="{x:Bind ViewModel.IsSaveAvailable, Mode=OneWay}" Style="{ThemeResource AccentButtonStyle}" Command="{x:Bind ViewModel.SaveChangesCommand}"
+                    Width="100" Content="Save" AccessKey="S" TabIndex="0"/>
+                <Button x:Uid="CancelButton" IsEnabled="{x:Bind ViewModel.IsCancelAvailable, Mode=OneWay}" Command="{x:Bind ViewModel.ReloadCommand}"
+                        Width="100" AccessKey="C"  TabIndex="1"/>
+            </StackPanel>
+        </Border>
     </Grid>
 
     <Page.Resources>

--- a/src/PPM.Application/Program.cs
+++ b/src/PPM.Application/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Affinity_manager.Hosting;
+using Affinity_manager.Model;
 using Affinity_manager.Model.CRUD;
 using Affinity_manager.Model.DataGathering;
 using Affinity_manager.ViewModels;
@@ -40,6 +41,7 @@ namespace Affinity_manager
             services.AddSingleton(_ => ProcessesMonitor.CreateAndStart()); // Monitors running processes, must be one.
             services.AddSingleton<IApplicationIconsLoader, ApplicationIconsLoader>(); // must be one because it uses shared resource - access to file system that may crash.
             services.AddTransient(_ => StartMenuShortcutsGatherer.CreateAndStart());
+            services.AddTransient<IProcessConfigurationApplier, ProcessConfigurationApplier>();
             services.AddTransient<IAutocompleteProvider, AutocompleteView>((provider) =>
             {
                 AutocompleteView view = new(provider.GetRequiredService<IApplicationIconsLoader>());

--- a/src/PPM.Application/Strings/en-us/Resources.resw
+++ b/src/PPM.Application/Strings/en-us/Resources.resw
@@ -132,8 +132,17 @@
   <data name="ApplicationNameColumn.Text" xml:space="preserve">
     <value>Application Name</value>
   </data>
-  <data name="ApplyButton.Content" xml:space="preserve">
-    <value>Apply</value>
+  <data name="ApplyOnRunningButton.Content" xml:space="preserve">
+    <value>Apply on running processes</value>
+  </data>
+  <data name="ApplyOnRunningButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Finds related running processes and applies the configuration on them.</value>
+  </data>
+  <data name="SaveButton.Content" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="SaveButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Saves the changes. Configuration will be applied next time when the new instance of the process will start.</value>
   </data>
   <data name="CancelButton.Content" xml:space="preserve">
     <value>Cancel</value>
@@ -170,7 +179,16 @@
   <data name="VeryLowCheckBox.Content" xml:space="preserve">
     <value>Very Low</value>
   </data>
+  <data name="ApplyOnRunningCheckBox.Content" xml:space="preserve">
+    <value>Also apply on running processes</value>
+  </data>
+  <data name="ApplyOnRunningCheckBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Instruct PPM to search for running processes and apply selected options during the save operation.</value>
+  </data>
   <data name="ResetButton.Content" xml:space="preserve">
     <value>Default</value>
+  </data>
+  <data name="ResetButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Resets the configuration to the default state.</value>
   </data>
 </root>

--- a/src/PPM.Application/Strings/uk-UA/Resources.resw
+++ b/src/PPM.Application/Strings/uk-UA/Resources.resw
@@ -30,9 +30,6 @@
   <data name="IoPriorityColumn.Text" xml:space="preserve">
     <value>Пріоритет Вх/Вих та ОЗП</value>
   </data>
-  <data name="ApplyButton.Content" xml:space="preserve">
-    <value>Застосувати</value>
-  </data>
   <data name="CancelButton.Content" xml:space="preserve">
     <value>Відмінити</value>
   </data>
@@ -67,5 +64,26 @@
   </data>
   <data name="ResetButton.Content" xml:space="preserve">
     <value>За замовчуванням</value>
+  </data>
+  <data name="SaveButton.Content" xml:space="preserve">
+    <value>Зберегти</value>
+  </data>
+  <data name="ApplyOnRunningCheckBox.Content" xml:space="preserve">
+    <value>Також застосувати до запущених процесів</value>
+  </data>
+  <data name="ApplyOnRunningCheckBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Вказати PPM, що під час зберігання треба знайти та застосувати налаштування до запущений процесів.</value>
+  </data>
+  <data name="SaveButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Зберігає зміни. Налаштування будуть застосовані до процесів, які будуть запущені у майбутньому.</value>
+  </data>
+  <data name="ApplyOnRunningButton.Content" xml:space="preserve">
+    <value>Застосувати до запущений процесів</value>
+  </data>
+  <data name="ApplyOnRunningButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Знайти запущені процеси та застосувати ці налаштування до них.</value>
+  </data>
+  <data name="ResetButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Скидує до налаштувань за замовчуванням.</value>
   </data>
 </root>

--- a/src/PPM.Application/ViewModels/IMainPageViewModel.cs
+++ b/src/PPM.Application/ViewModels/IMainPageViewModel.cs
@@ -10,14 +10,16 @@ namespace Affinity_manager.ViewModels
         string? NewProcessName { get; set; }
         IReadOnlyObservableCollection<ProcessConfigurationView> ProcessesConfigurations { get; }
         ProcessConfigurationView? SelectedView { get; set; }
-        bool SaveCancelAvailable { get; }
+        bool IsSaveAvailable { get; }
         bool IsInterfaceVisible { get; }
+        bool ApplyOnRunningProcesses { get; set; }
 
         public IRelayCommand AddCommand { get; }
 
         public IAsyncRelayCommand SaveChangesCommand { get; }
 
         public IAsyncRelayCommand ReloadCommand { get; }
+        bool IsCancelAvailable { get; }
 
         ProcessInfoView[] GetAutoCompleteList();
     }

--- a/src/PPM.Application/ViewWrappers/ProcessConfigurationViewFactory.cs
+++ b/src/PPM.Application/ViewWrappers/ProcessConfigurationViewFactory.cs
@@ -8,16 +8,18 @@ namespace Affinity_manager.ViewWrappers
     {
         private readonly IOptionsProvider _optionsProvider;
         private readonly IEqualityComparer<ProcessConfigurationView> _comparer;
+        private readonly IProcessConfigurationApplier _configurationApplier;
 
-        public ProcessConfigurationViewFactory(IOptionsProvider optionsProvider, IEqualityComparer<ProcessConfigurationView> comparer)
+        public ProcessConfigurationViewFactory(IOptionsProvider optionsProvider, IEqualityComparer<ProcessConfigurationView> comparer, IProcessConfigurationApplier configurationApplier)
         {
             _optionsProvider = optionsProvider;
             _comparer = comparer;
+            _configurationApplier = configurationApplier;
         }
 
         public ProcessConfigurationView Create(ProcessConfiguration configuration)
         {
-            return new ProcessConfigurationView(configuration, _optionsProvider);
+            return new ProcessConfigurationView(configuration, _optionsProvider, _configurationApplier);
         }
 
         public BindingCollectionWithUniqunessCheck<ProcessConfigurationView> CreateCollection(IEnumerable<ProcessConfiguration> processConfigurations)

--- a/src/PPM.TestApp/PPM.TestApp.csproj
+++ b/src/PPM.TestApp/PPM.TestApp.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<SelfContained>true</SelfContained>
+	<TrimMode>full</TrimMode>
   </PropertyGroup>
 
 </Project>

--- a/src/PPM.Unsafe/IoPriorityHint.cs
+++ b/src/PPM.Unsafe/IoPriorityHint.cs
@@ -1,0 +1,10 @@
+namespace PPM.Unsafe
+{
+    public enum IoPriorityHint
+    {
+        VeryLow = 0,
+        Low = 1,
+        Normal = 2,
+        High = 3
+    }
+}

--- a/src/PPM.Unsafe/NTSTATUS.cs
+++ b/src/PPM.Unsafe/NTSTATUS.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+using Vanara.PInvoke;
+
+namespace PPM.Unsafe
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal readonly partial struct NTSTATUS
+    {
+        [LibraryImport(Lib.NtDll)]
+        private static partial ulong RtlNtStatusToDosError(nint ntstatus);
+
+        public readonly nint Value;
+
+        public int Win32ErrorCode
+        {
+            get
+            {
+                unchecked
+                {
+                    return (int)RtlNtStatusToDosError(Value);
+                }
+            }
+        }
+    }
+}

--- a/src/PPM.Unsafe/PagePriorityInformation.cs
+++ b/src/PPM.Unsafe/PagePriorityInformation.cs
@@ -1,0 +1,11 @@
+namespace PPM.Unsafe
+{
+    public enum PagePriorityInformation
+    {
+        VeryLow = 1,
+        Low = 2,
+        Medium = 3,
+        BelowNormal = 4,
+        Normal = 5
+    }
+}

--- a/src/PPM.Unsafe/ProcessExtenstions.cs
+++ b/src/PPM.Unsafe/ProcessExtenstions.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Vanara.PInvoke;
+
+namespace PPM.Unsafe
+{
+    public static partial class ProcessExtenstions
+    {
+        [LibraryImport(Lib.NtDll)]
+        private static partial NTSTATUS NtSetInformationProcess(
+            IntPtr ProcessHandle,
+            ProcessInfoClass ProcessInformationClass,
+            ref IntPtr ProcessInformation,
+            uint ProcessInformationLength);
+
+        [LibraryImport(Lib.NtDll)]
+        private static partial NTSTATUS NtQueryInformationProcess(
+            IntPtr ProcessHandle,
+            ProcessInfoClass ProcessInformationClass,
+            ref IntPtr ProcessInformation,
+            uint ProcessInformationLength,
+            out uint ReturnLength);
+
+
+        /// <summary>
+        /// Sets the I/O priority of the specified process.
+        /// </summary>
+        /// <param name="process">Process to set I/O priority.</param>
+        /// <param name="priority">I/O priority value.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="process"/> is <see langword="null"/>.</exception>"
+        /// <exception cref="InvalidOperationException">If process exited.</exception>
+        /// <exception cref="Win32Exception">If set of priority failed.</exception>"
+        public static void SetIoPriority(this Process process, in IoPriorityHint priority)
+        {
+            ArgumentNullException.ThrowIfNull(process, nameof(process));
+
+            nint internalPriority = (IntPtr)priority;
+            var result = NtSetInformationProcess(process.Handle, ProcessInfoClass.ProcessIoPriority, ref internalPriority, sizeof(IoPriorityHint));
+
+            if (result.Value != 0)
+            {
+                throw new Win32Exception(result.Win32ErrorCode);
+            }
+        }
+
+        /// <summary>
+        /// Gets the I/O priority of the specified process.
+        /// </summary>
+        /// <param name="process">Process to get I/O priority.</param>
+        /// <returns>I/O priority of the process.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="process"/> is <see langword="null"/>.</exception>""
+        /// <exception cref="InvalidOperationException">If get of priority failed.</exception>
+        /// <exception cref="Win32Exception">If get of priority failed.</exception>"
+        public static IoPriorityHint GetIoPriority(this Process process)
+        {
+            ArgumentNullException.ThrowIfNull(process, nameof(process));
+            nint internalPriority = 0;
+            NTSTATUS result = NtQueryInformationProcess(process.Handle, ProcessInfoClass.ProcessIoPriority, ref internalPriority, sizeof(IoPriorityHint), out _);
+            if (result.Value != 0)
+            {
+                throw new Win32Exception(result.Win32ErrorCode);
+            }
+            return (IoPriorityHint)internalPriority;
+        }
+
+        /// <summary>
+        /// Sets the memory priority of the specified process.
+        /// </summary>
+        /// <param name="process">Process to set memory (page) priority.</param>
+        /// <param name="priority">Memory priority value.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="process"/> is <see langword="null"/>.</exception>"
+        /// <exception cref="InvalidOperationException">If set of priority failed.</exception>
+        /// <exception cref="Win32Exception">If set of priority failed.</exception>""
+        public static void SetMemoryPriority(this Process process, in PagePriorityInformation priority)
+        {
+            ArgumentNullException.ThrowIfNull(process, nameof(process));
+
+            nint internalPriority = (IntPtr)priority;
+            NTSTATUS result = NtSetInformationProcess(process.Handle, ProcessInfoClass.ProcessPagePriority, ref internalPriority, sizeof(PagePriorityInformation));
+            if (result.Value != 0)
+            {
+                throw new Win32Exception(result.Win32ErrorCode);
+            }
+        }
+
+        /// <summary>
+        /// Gets the memory priority of the specified process.
+        /// </summary>
+        /// <param name="process">Process to get memory priority.</param>
+        /// <returns>Memory priority of the process.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="process"/> is <see langword="null"/>.</exception>""
+        /// <exception cref="InvalidOperationException">If get of priority failed.</exception>
+        /// <exception cref="Win32Exception">If get of priority failed.</exception>""
+        public static PagePriorityInformation GetMemoryPriority(this Process process)
+        {
+            ArgumentNullException.ThrowIfNull(process, nameof(process));
+
+            nint internalPriority = 0;
+            NTSTATUS result = NtQueryInformationProcess(process.Handle, ProcessInfoClass.ProcessPagePriority, ref internalPriority, sizeof(PagePriorityInformation), out _);
+            if (result.Value != 0)
+            {
+                throw new Win32Exception(result.Win32ErrorCode);
+            }
+            return (PagePriorityInformation)internalPriority;
+        }
+    }
+}

--- a/src/PPM.Unsafe/ProcessInfoClass.cs
+++ b/src/PPM.Unsafe/ProcessInfoClass.cs
@@ -1,0 +1,8 @@
+namespace PPM.Unsafe
+{
+    internal enum ProcessInfoClass
+    {
+        ProcessIoPriority = 33,
+        ProcessPagePriority = 39
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature to apply process configurations to running processes.

#### PR Summary
Introduces a new interface `IProcessConfigurationApplier` and updates related classes and tests to support applying configurations to running processes.
- Added `IProcessConfigurationApplier` interface and implemented it in `ProcessConfigurationApplier.cs`.
- Updated `MainPageViewModel.cs` and `MainPage.xaml` to include new UI elements and logic for applying configurations.
- Modified test files (`MainPageViewModelTests.cs`, `ProcessConfigurationViewTests.cs`, etc.) to accommodate the new dependency.
- Updated `Program.cs` to include `IProcessConfigurationApplier` in the services.
- Made UI and resource updates in `MainPage.xaml` and `Resources.resw` for new buttons and tooltips.
