### PR TITLE
Added additional validation on process name.

### DIFF
--- a/src/PPM.Application/Model/ProcessConfiguration.cs
+++ b/src/PPM.Application/Model/ProcessConfiguration.cs
@@ -1,4 +1,7 @@
+using System;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Affinity_manager.Model
@@ -29,8 +32,9 @@ namespace Affinity_manager.Model
         }
 
         [FileExtensions(Extensions = ".exe", ErrorMessageResourceType = typeof(Strings.Validation), ErrorMessageResourceName = nameof(Strings.Validation.ProcessNameMustHaveExeExtension))]
+        [MaxLength(100, ErrorMessageResourceType = typeof(Strings.Validation), ErrorMessageResourceName = nameof(Strings.Validation.ProcessNameMustBeLessThanHundredChars))]
+        [CustomValidation(typeof(ProcessConfiguration), nameof(ValidateNameAsPath))]
         public string Name { get; }
-
 
         public bool IsEmpty
         {
@@ -54,6 +58,18 @@ namespace Affinity_manager.Model
         public override string ToString()
         {
             return Name;
+        }
+
+        public static ValidationResult? ValidateNameAsPath(string name, ValidationContext context)
+        {
+            ProcessConfiguration configuration = (ProcessConfiguration)context.ObjectInstance;
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            if (configuration.Name.Any(character => invalidChars.Contains(character)))
+            {
+                return new ValidationResult(Strings.Validation.ProcessNameCannotContainInvalidCharacters);
+            }
+
+            return ValidationResult.Success;
         }
     }
 }

--- a/src/PPM.Application/MultilingualResources/PPM.Application.uk-UA.xlf
+++ b/src/PPM.Application/MultilingualResources/PPM.Application.uk-UA.xlf
@@ -283,6 +283,14 @@
           <source>Process Name must have ".exe" extension.</source>
           <target state="final">Назва застосунка мусить мати розширення ".exe".</target>
         </trans-unit>
+        <trans-unit id="ProcessNameCannotContainInvalidCharacters" translate="yes" xml:space="preserve">
+          <source>Process name cannot contain invalid characters.</source>
+          <target state="translated">Ім'я процесу не може мати неприпустимий символів.</target>
+        </trans-unit>
+        <trans-unit id="ProcessNameMustBeLessThanHundredChars" translate="yes" xml:space="preserve">
+          <source>Process name must not exceed 100 characters.</source>
+          <target state="translated">Ім'я процесу не може бути довше за 100 символів.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/PPM.Application/PPM.Application.csproj
+++ b/src/PPM.Application/PPM.Application.csproj
@@ -143,9 +143,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Assets\" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="..\pm_affinityservice\target\release\PPM_Service.exe" Link="PPM_Service.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -363,5 +360,8 @@
     <PRIResource Update="Strings\en-us\Validation.resw">
       <Generator>ReswPlusAdvancedGenerator</Generator>
     </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Assets\" />
   </ItemGroup>
 </Project>

--- a/src/PPM.Application/Strings/en-us/Validation.resw
+++ b/src/PPM.Application/Strings/en-us/Validation.resw
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ProcessNameCannotContainInvalidCharacters" xml:space="preserve">
+    <value>Process name cannot contain invalid characters.</value>
+  </data>
+  <data name="ProcessNameMustBeLessThanHundredChars" xml:space="preserve">
+    <value>Process name must not exceed 100 characters.</value>
+  </data>
   <data name="ProcessNameMustHaveExeExtension" xml:space="preserve">
     <value>Process Name must have ".exe" extension.</value>
   </data>

--- a/src/PPM.Application/Strings/uk-UA/Validation.resw
+++ b/src/PPM.Application/Strings/uk-UA/Validation.resw
@@ -15,4 +15,10 @@
   <data name="ProcessNameMustHaveExeExtension" xml:space="preserve">
     <value>Назва застосунка мусить мати розширення ".exe".</value>
   </data>
+  <data name="ProcessNameCannotContainInvalidCharacters" xml:space="preserve">
+    <value>Ім'я процесу не може мати неприпустимий символів.</value>
+  </data>
+  <data name="ProcessNameMustBeLessThanHundredChars" xml:space="preserve">
+    <value>Ім'я процесу не може бути довше за 100 символів.</value>
+  </data>
 </root>


### PR DESCRIPTION
Added additional validation on process name.

#### PR Classification
New feature: Added validation for process name length and invalid characters.

#### PR Summary
Introduced validation for process name length and invalid characters, and updated related resources and translations.
- `ProcessConfiguration.cs`: Added `using` directives, `[MaxLength(100)]` attribute, and `ValidateNameAsPath` method.
- `PPM.Application.uk-UA.xlf`: Included new translation entries for validation messages.
- `PPM.Application.csproj`: Re-included the `Assets` folder.
- `Validation.resw`: Added new resource entries and Ukrainian translations for validation messages.
