### PR TITLE
Fixed the problem with removing affinities from profiles during the update.

### DIFF
--- a/src/PPM.Installer/Actions.wxs
+++ b/src/PPM.Installer/Actions.wxs
@@ -2,7 +2,7 @@
 	<Fragment>
 		<CustomAction Id="RemoveProfiles" FileRef="MainExecutable" ExeCommand="--clear" Execute="immediate"/>
 		<InstallExecuteSequence>
-			<Custom Action="RemoveProfiles" Before='RemoveFiles' Condition='(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")'/>
+			<Custom Action="RemoveProfiles" Before='RemoveRegistryValues' Condition='(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")'/>
 		</InstallExecuteSequence>
 	</Fragment>
 </Wix>

--- a/src/PPM.Installer/AppComponents.wxs
+++ b/src/PPM.Installer/AppComponents.wxs
@@ -22,7 +22,13 @@
 		<Files Include="!(bindpath.x64)\en-us\*.mui" Directory="EN_US"/>
 		<File Name="appsettings.json" Source="!(bindpath.x64)\appsettings.json"/>
 		<Component Id="Registry_HKLM" Guid="1F167EEE-4394-4FBB-87A1-3AEA39137E64">
-			<RegistryKey Id="Settings" Root="HKLM" Key="SOFTWARE\Processes Priority Manager\" ForceDeleteOnUninstall="yes"></RegistryKey>
+			<RegistryKey Root="HKLM" Key="SOFTWARE\Processes Priority Manager\">
+				<RegistryKey Key="Image Options">
+					<!-- This is a dummy value, that is used to make sure that the key is removed on uninstallation.
+					     The tool saves some options in this key that must be removed. These options are removed in RemoveProfiles custom action.-->
+					<RegistryValue Name="Installed" Value="1" Type="integer" KeyPath="yes"/>
+				</RegistryKey>
+			</RegistryKey>
 		</Component>
     </ComponentGroup>
   </Fragment>

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("0.6.1.0")]
-[assembly: AssemblyFileVersion("6.1.0.0")]
+[assembly: AssemblyFileVersion("0.6.1.0")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Processes Priority Manager")]
 [assembly: AssemblyCopyright("Copyright ©  2025")]

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: System.Reflection.AssemblyVersionAttribute("0.6.0.0")]
-[assembly: System.Reflection.AssemblyFileVersionAttribute("0.6.0.0")]
+[assembly: AssemblyVersion("0.6.1.0")]
+[assembly: AssemblyFileVersion("6.1.0.0")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Processes Priority Manager")]
 [assembly: AssemblyCopyright("Copyright ©  2025")]

--- a/src/pm_affinityservice/Cargo.toml
+++ b/src/pm_affinityservice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pm_affinityservice"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [package.metadata.winres]


### PR DESCRIPTION
Fixed the problem with removing affinities from profiles during the update.

#### PR Classification
Bug fix to correct the execution sequence of custom actions and ensure proper registry key removal during uninstallation.

#### PR Summary
This pull request modifies the execution sequence of custom actions and updates registry key handling to ensure proper uninstallation.
- `Actions.wxs`: `RemoveProfiles` custom action now runs before `RemoveRegistryValues`.
- `AppComponents.wxs`: Added nested `RegistryKey` for `Image Options` with a dummy `RegistryValue` and removed `ForceDeleteOnUninstall` attribute.
- `SolutionInfo.cs`: Updated assembly version to `0.6.1.0` and file version to `0.6.1.0`.
