### PR TITLE
Updated WinSDK to 1.7, Wix to 6 and other dependencies are updated.

### DIFF
--- a/src/PPM.Application.IntegrationTests/PPM.Application.IntegrationTests.csproj
+++ b/src/PPM.Application.IntegrationTests/PPM.Application.IntegrationTests.csproj
@@ -34,15 +34,15 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FluentAssertions" Version="[7.0.0]" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250401001" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+		<PackageReference Include="NUnit.Analyzers" Version="4.7.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 
 	</ItemGroup>
 	<ItemGroup>
@@ -58,4 +58,13 @@
 	<ItemGroup>
 	  <PRIResource Remove="TestResults\**" />
 	</ItemGroup>
+	<!--We do not use WebView. It also produces build warnings.-->
+	<Target Name="RemoveUnnecessaryWebView2References" AfterTargets="ResolvePackageDependenciesForBuild">
+		<ItemGroup>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.Core'"/>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.WinForms'"/>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.Wpf'"/>
+			<Reference Remove="@(ReferenceToBeRemoved)"/>
+		</ItemGroup>
+	</Target>
 </Project>

--- a/src/PPM.Application.Tests/PPM.Application.Tests.csproj
+++ b/src/PPM.Application.Tests/PPM.Application.Tests.csproj
@@ -34,16 +34,16 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FluentAssertions" Version="[7.0.0]" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250401001" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+		<PackageReference Include="NUnit.Analyzers" Version="4.7.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-		<PackageReference Include="Verify.NUnit" Version="28.9.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+		<PackageReference Include="Verify.NUnit" Version="30.0.0" />
 
 	</ItemGroup>
 	<ItemGroup>
@@ -68,4 +68,13 @@
 	<ItemGroup>
 	  <PRIResource Remove="TestResults\**" />
 	</ItemGroup>
+	<!--We do not use WebView. It also produces build warnings.-->
+	<Target Name="RemoveUnnecessaryWebView2References" AfterTargets="ResolvePackageDependenciesForBuild">
+		<ItemGroup>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.Core'"/>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.WinForms'"/>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.Wpf'"/>
+			<Reference Remove="@(ReferenceToBeRemoved)"/>
+		</ItemGroup>
+	</Target>
 </Project>

--- a/src/PPM.Application/PPM.Application.csproj
+++ b/src/PPM.Application/PPM.Application.csproj
@@ -62,15 +62,15 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250401001" />
     <PackageReference Include="ReswPlus" Version="0.3.1.5" Publish="false">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
     <PackageReference Include="securifybv.ShellLink" Version="0.1.0" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.1" />
-    <PackageReference Include="Vanara.PInvoke.ComCtl32" Version="4.0.4" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.4" />
+    <PackageReference Include="Vanara.PInvoke.ComCtl32" Version="4.1.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
@@ -148,7 +148,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Target Name="WindowsAppSdk_Issue_3843_Workaround_MsixContent" AfterTargets="AddMicrosoftWindowsAppSDKPayloadFiles">
+	<!--We do not use WebView. It also produces build warnings.-->
+	<Target Name="RemoveUnnecessaryWebView2References" AfterTargets="ResolvePackageDependenciesForBuild">
+		<ItemGroup>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.Core'"/>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.WinForms'"/>
+			<ReferenceToBeRemoved Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.Wpf'"/>
+			<Reference Remove="@(ReferenceToBeRemoved)"/>
+		</ItemGroup>
+	</Target>
+    <Target Name="WindowsAppSdk_Issue_3843_Workaround_MsixContent" AfterTargets="AddMicrosoftWindowsAppSDKPayloadFiles">
     <ItemGroup>
       <None Remove="$(MicrosoftWindowsAppSDKMsixContent)\DeploymentAgent.exe" />
       <None Remove="$(MicrosoftWindowsAppSDKMsixContent)\Microsoft.Web.WebView2.Core.dll" />

--- a/src/PPM.Installer/AppComponents.wxs
+++ b/src/PPM.Installer/AppComponents.wxs
@@ -12,7 +12,9 @@
 			</ServiceInstall>
 			<ServiceControl Id="PPM_Service_control" Name="PPM_Service" Start="install" Stop="both" Remove="uninstall" Wait="no"/>
 		</Component>
-		<Files Include="!(bindpath.x64)\*.dll"/>
+		<Files Include="!(bindpath.x64)\*.dll">
+			<Exclude Files="!(bindpath.x64)\Microsoft.Windows.Widgets.dll"></Exclude>
+		</Files>
 		<Files Include="!(bindpath.x64)\*.runtimeconfig.json"/>
 		<Files Include="!(bindpath.x64)\*.pri"/>
 		<Files Include="!(bindpath.x64)\**.png">

--- a/src/PPM.Installer/PPM.Installer.wixproj
+++ b/src/PPM.Installer/PPM.Installer.wixproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="WixToolset.Sdk/5.0.2">
+﻿<Project Sdk="WixToolset.Sdk/6.0.0">
   <ItemGroup>
-    <PackageReference Include="WixToolset.Heat" Version="5.0.2" />
-    <PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="5.0.2" />
+    <PackageReference Include="WixToolset.Heat" Version="6.0.0" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="6.0.0" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PPM.Application\PPM.Application.csproj" Publish="true" />

--- a/src/PPM.InstallerBundle/PPM.InstallerBundle.wixproj
+++ b/src/PPM.InstallerBundle/PPM.InstallerBundle.wixproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="WixToolset.Sdk/5.0.2">
+﻿<Project Sdk="WixToolset.Sdk/6.0.0">
   <PropertyGroup>
     <OutputType>Bundle</OutputType>
     <OutputName>PPM_Setup-$(Platform)</OutputName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.Bal.wixext" Version="5.0.2" />
+    <PackageReference Include="WixToolset.Bal.wixext" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <BindPath Include="obj\x64\$(Configuration)\publish\Affinity_manager">

--- a/src/PPM.Unsafe/PPM.Unsafe.csproj
+++ b/src/PPM.Unsafe/PPM.Unsafe.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Vanara.PInvoke.User32" Version="4.0.4" />
+    <PackageReference Include="Vanara.PInvoke.User32" Version="4.1.3" />
   </ItemGroup>
 
 </Project>

--- a/src/pm_affinityservice/Cargo.toml
+++ b/src/pm_affinityservice/Cargo.toml
@@ -12,15 +12,15 @@ name = "PPM_Service"
 path = "src/main.rs"
 
 [dependencies]
-windows-service = "0.7"
+windows-service = "0.8"
 log = "0.4"
 simplelog = "0.12"
-wmi = "0.15"
+wmi = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 winreg = "0.55"
 
 [dependencies.windows]
-version = "0.59"
+version = "0.61"
 features = [
     "Win32_System_Threading",
     "Win32_System_ProcessStatus"


### PR DESCRIPTION
#### PR Classification
Dependency updates and code cleanup.

#### PR Summary
This pull request updates several NuGet package versions for improved functionality and adds a target to remove unnecessary WebView2 references. Key changes include:
- **PPM.Application.IntegrationTests.csproj**: Updated `Microsoft.NET.Test.Sdk`, `Microsoft.WindowsAppSDK`, `NUnit.Analyzers`, and `NUnit3TestAdapter` to their latest versions; added `RemoveUnnecessaryWebView2References` target.
- **PPM.Application.Tests.csproj**: Similar updates to package versions and added the `RemoveUnnecessaryWebView2References` target.
- **PPM.Application.csproj**: Updated `Microsoft.Extensions.Hosting`, `System.ServiceProcess.ServiceController`, and `Vanara.PInvoke.ComCtl32` versions; added `RemoveUnnecessaryWebView2References` target.
- **AppComponents.wxs**: Excluded `Microsoft.Windows.Widgets.dll` from the installer files.
- **Cargo.toml**: Updated `windows-service` and `wmi` dependencies to their latest versions.
